### PR TITLE
Allow using unstable api in runner and checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkg/deno/testdata/**/*.out
 pkg/deno/testdata/**/*.out
+
+deno.lock

--- a/pkg/deno/checker.go
+++ b/pkg/deno/checker.go
@@ -47,6 +47,7 @@ func (c *Checker) CheckFile(ctx context.Context, opts CheckFileOptions) error {
 		ctx,
 		"deno",
 		"check",
+		"--unstable",
 		"--quiet",
 		targetScript,
 	)

--- a/pkg/deno/runner.go
+++ b/pkg/deno/runner.go
@@ -106,6 +106,7 @@ func (r *Runner) RunFile(ctx context.Context, opts RunFileOptions) (*RunFileResu
 		ctx,
 		"deno",
 		"run",
+		"--unstable",
 		"--quiet",
 		fmt.Sprintf("--allow-read=%v,%v", targetScript, input),
 		fmt.Sprintf("--allow-write=%v", output),


### PR DESCRIPTION
- Allow using Deno.createHttpClient
ref https://github.com/authgear/authgear-server/issues/2829