### PR TITLE
Simplifying packaging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,15 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
         go-version-file: "./go.mod"
+    # setup-deno@v1 uses deno v1 by default.
+    # setup-deno@v2 uses deno v2 by default.
+    # So even there is a possible upgrade, we do not upgrade.
     - uses: denoland/setup-deno@v1
       with:
         deno-version: "1.41.3"
@@ -33,7 +36,7 @@ jobs:
       if: ${{ !cancelled() }}
 
   distribute:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: test
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,14 @@ jobs:
     needs: test
     steps:
     - uses: actions/checkout@v4
-    - run: make build-image
+    - name: Set up inputs to build-push-action
+      id: build-push-action-input
+      run: |
+        make gh-actions-env | tee -a "$GITHUB_OUTPUT"
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Login to Quay.io
       if: ${{ github.repository == 'authgear/authgear-deno' && github.event_name == 'push' }}
       uses: docker/login-action@v3
@@ -48,5 +55,12 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-    - run: make push-image
-      if: ${{ github.repository == 'authgear/authgear-deno' && github.event_name == 'push' }}
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ steps.build-push-action-input.outputs.BUILD_CONTEXT }}
+        file: ${{ steps.build-push-action-input.outputs.DOCKERFILE }}
+        tags: ${{ steps.build-push-action-input.outputs.IMAGE_TAG }}
+        platforms: linux/amd64,linux/arm64
+        pull: true
+        push: ${{ github.repository == 'authgear/authgear-deno' && github.event_name == 'push' }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,11 +2,6 @@ linters:
   disable:
   - wrapcheck
   - gofumpt
-  - scopelint
-  - deadcode
-  - maligned
-  - structcheck
-  - varcheck
   - revive
   - tagalign
   - depguard

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.21.9
+golang 1.23.6
 deno 1.41.3

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMAGE ?= quay.io/theauthgear/authgear-deno:$(GIT_HASH)
 
 .PHONY: vendor
 vendor:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.55.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.64.2
 	go mod download
 
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 GIT_HASH ?= git-$(shell git rev-parse --short=12 HEAD)
-IMAGE ?= quay.io/theauthgear/authgear-deno:$(GIT_HASH)
+BUILD_CONTEXT ::= .
+DOCKERFILE ::= ./cmd/server/Dockerfile
+IMAGE_TAG ?= quay.io/theauthgear/authgear-deno:$(GIT_HASH)
 
 .PHONY: vendor
 vendor:
@@ -34,8 +36,8 @@ check-tidy:
 
 .PHONY: build-image
 build-image:
-	docker build --pull --file ./cmd/server/Dockerfile --tag $(IMAGE) .
+	docker build --pull --file $(DOCKERFILE) --tag $(IMAGE_TAG) $(BUILD_CONTEXT)
 
-.PHONY: push-image
-push-image:
-	docker push $(IMAGE)
+.PHONY: gh-actions-env
+gh-actions-env:
+	@printf "BUILD_CONTEXT=%s\nDOCKERFILE=%s\nIMAGE_TAG=%s\n" $(BUILD_CONTEXT) $(DOCKERFILE) $(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -23,37 +23,37 @@ $ make start
 
 ```
 $ curl --request POST \
-  --url http://localhost:8090/ \
+  --url http://localhost:8090/run \
   --header 'Content-Type: application/json' \
   --data '{
 	"script": "export default async function addOne(a) { return a + 1; }",
 	"input": 42
 }'
-{"output":43}
+{"output":43,"stderr":{},"stdout":{}}
 ```
 
 ### Evaluate a function with side-effects
 
 ```
 $ curl --request POST \
-  --url http://localhost:8090/ \
+  --url http://localhost:8090/run \
   --header 'Content-Type: application/json' \
   --data '{
 	"script": "export default async function addOne(a) { console.log('\''hello'\''); return a + 1; }",
 	"input": 42
 }'
-{"output":43,"stdout":"hello\n"}
+{"output":43,"stderr":{},"stdout":{"string":"hello\n"}}
 ```
 
 ### Evaluate a malicious function
 
 ```
 $ curl --request POST \
-  --url http://localhost:8090/ \
+  --url http://localhost:8090/run \
   --header 'Content-Type: application/json' \
   --data '{
 	"script": "export default async function malicious() { Deno.remove('\''/'\'', { recursive: true}) }",
 	"input": 42
 }'
-{"error":"exit status 1","stderr":"⚠️  ┌ Deno requests write access to \"/\".\r\n   ├ Requested by `Deno.remove()` API\r\n   ├ Run again with --allow-write to bypass this prompt.\r\n   └ Allow? [y/n] (y = yes, allow; n = no, deny) \u003e n\r\n\u001b[4A\u001b[0J❌ Denied write access to \"/\".\r\nerror: Uncaught (in promise) PermissionDenied: Requires write access to \"/\", run again with the --allow-write flag\r\n    at async Object.remove (deno:runtime/js/30_fs.js:167:5)\r\n"}
+{"error":"exit status 1","stderr":{"string":"┌ ⚠️  Deno requests write access to \"/\".\r\n├ Requested by `Deno.remove()` API.\r\n├ Run again with --allow-write to bypass this prompt.\r\n└ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all write permissions) \u003e n\r\n\u001b[4A\u001b[0J❌ Denied write access to \"/\".\r\nerror: Uncaught (in promise) PermissionDenied: Requires write access to \"/\", run again with the --allow-write flag\r\nexport default async function malicious() { Deno.remove('/', { recursive: true}) }\r\n                                                 ^\r\n    at Object.remove (ext:deno_fs/30_fs.js:259:9)\r\n    at Module.malicious (file:///var/folders/8x/b6m06y8j6xdfhnb574s1yn_00000gn/T/authgear-deno-script.3385027413.ts:1:50)\r\n    at file:///Users/louischan/authgear-deno/pkg/deno/runner.ts:7:47\r\n"},"stdout":{}}
 ```

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,20 +1,20 @@
-FROM golang:1.21.9-bookworm as stage1
+FROM quay.io/theauthgear/golang:1.23.6-noble AS stage1
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN make build
 
-FROM denoland/deno:bin-1.41.3 as stage2
+FROM denoland/deno:bin-1.41.3 AS stage2
 
-FROM debian:bookworm-slim
+FROM ubuntu:noble
 ENV RUNNER_SCRIPT=/app/runner.ts
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic-dev \
     libmagic-mgc \
     ca-certificates \
-    mime-support \
+    media-types \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -8,7 +8,6 @@ RUN make build
 FROM denoland/deno:bin-1.41.3 AS stage2
 
 FROM ubuntu:noble
-ENV RUNNER_SCRIPT=/app/runner.ts
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic-dev \
@@ -19,7 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 COPY --from=stage1 /src/authgear-deno /usr/local/bin/
-COPY --from=stage1 /src/pkg/deno/runner.ts /app/
 COPY --from=stage2 /deno /usr/local/bin/
 EXPOSE 8090
 CMD ["authgear-deno"]

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -8,7 +8,6 @@ import (
 
 type Config struct {
 	ListenAddr                      string `envconfig:"LISTEN_ADDR" default:"0.0.0.0:8090"`
-	RunnerScript                    string `envconfig:"RUNNER_SCRIPT" default:"./pkg/deno/runner.ts"`
 	DisallowGlobalUnicast           bool   `envconfig:"DISALLOW_GLOBAL_UNICAST" default:"false"`
 	DisallowInterfaceLocalMulticast bool   `envconfig:"DISALLOW_INTERFACE_LOCAL_MULTICAST" default:"true"`
 	DisallowLinkLocalUnicast        bool   `envconfig:"DISALLOW_LINK_LOCAL_UNICAST" default:"true"`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,7 +16,6 @@ func main() {
 
 	http.Handle("/run", &handler.Runner{
 		Runner: &deno.Runner{
-			RunnerScript: cfg.RunnerScript,
 			Permissioner: deno.DisallowIPPolicy(cfg.IPPolicies()...),
 		},
 	})

--- a/flake.lock
+++ b/flake.lock
@@ -34,22 +34,6 @@
         "type": "github"
       }
     },
-    "go_1_21_9": {
-      "locked": {
-        "lastModified": 1714750952,
-        "narHash": "sha256-oOUdvPrO8CbupgDSaPou+Jv6GL+uQA2QlE33D7OLzkM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5fd8536a9a5932d4ae8de52b7dc08d92041237fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5fd8536a9a5932d4ae8de52b7dc08d92041237fc",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1736943799,
@@ -70,7 +54,6 @@
       "inputs": {
         "deno_1_41_3": "deno_1_41_3",
         "flake-utils": "flake-utils",
-        "go_1_21_9": "go_1_21_9",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,95 @@
+{
+  "nodes": {
+    "deno_1_41_3": {
+      "locked": {
+        "lastModified": 1712026416,
+        "narHash": "sha256-N/3VR/9e1NlN49p7kCiATiEY6Tzdo+CbrAG8kqCQKcI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "080a4a27f206d07724b88da096e27ef63401a504",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "080a4a27f206d07724b88da096e27ef63401a504",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "go_1_21_9": {
+      "locked": {
+        "lastModified": 1714750952,
+        "narHash": "sha256-oOUdvPrO8CbupgDSaPou+Jv6GL+uQA2QlE33D7OLzkM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5fd8536a9a5932d4ae8de52b7dc08d92041237fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5fd8536a9a5932d4ae8de52b7dc08d92041237fc",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1736943799,
+        "narHash": "sha256-BYsp8PA1j691FupfrLVOQzm4CaYaKtkh4U+KuGMnBWw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ae2fb9f1fb5fcf17fb59f25c2a881c170c501d6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "deno_1_41_3": "deno_1_41_3",
+        "flake-utils": "flake-utils",
+        "go_1_21_9": "go_1_21_9",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,31 @@
           packages = [
             pkgs.go
             deno
+
+            (pkgs.golangci-lint.overrideAttrs (
+              prev:
+              let
+                version = "1.64.2";
+              in
+              {
+                inherit version;
+                src = pkgs.fetchFromGitHub {
+                  owner = "golangci";
+                  repo = "golangci-lint";
+                  rev = "v${version}";
+                  hash = "sha256-ODnNBwtfILD0Uy2AKDR/e76ZrdyaOGlCktVUcf9ujy8=";
+                };
+                vendorHash = "sha256-/iq7Ju7c2gS7gZn3n+y0kLtPn2Nn8HY/YdqSDYjtEkI=";
+                # We do not actually override anything here,
+                # but if we do not repeat this, ldflags refers to the original version.
+                ldflags = [
+                  "-s"
+                  "-X main.version=${version}"
+                  "-X main.commit=v${version}"
+                  "-X main.date=19700101-00:00:00"
+                ];
+              }
+            ))
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+    go_1_21_9.url = "github:NixOS/nixpkgs/5fd8536a9a5932d4ae8de52b7dc08d92041237fc";
+    deno_1_41_3.url = "github:NixOS/nixpkgs/080a4a27f206d07724b88da096e27ef63401a504";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      go_1_21_9,
+      deno_1_41_3,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        go_1_21 = go_1_21_9.legacyPackages.${system}.go_1_21;
+        deno = deno_1_41_3.legacyPackages.${system}.deno;
+      in
+      {
+        devShells.default = pkgs.mkShellNoCC {
+          packages = [
+            go_1_21
+            deno
+          ];
+        };
+      }
+    );
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/authgear/authgear-deno
 
 // go1.21 supports toolchain
 // See https://go.dev/doc/toolchain
-go 1.21.9
+go 1.23.6
 
 require (
 	github.com/creack/pty v1.1.21

--- a/pkg/deno/permissioner.go
+++ b/pkg/deno/permissioner.go
@@ -2,6 +2,7 @@ package deno
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 )
@@ -23,7 +24,7 @@ func (e *ErrorInvalidIP) Error() string {
 	return fmt.Sprintf("invalid ip: %v", e.Value)
 }
 
-var ErrAllHost = fmt.Errorf("network permission without host is disallowed")
+var ErrAllHost = errors.New("network permission without host is disallowed")
 
 type ErrorNoIP struct {
 	Host string

--- a/pkg/deno/runner_test.go
+++ b/pkg/deno/runner_test.go
@@ -18,7 +18,6 @@ func TestRunner(t *testing.T) {
 	Convey("Runner", t, func() {
 		ctx := context.Background()
 		runner := &deno.Runner{
-			RunnerScript: "./runner.ts",
 			Permissioner: deno.DisallowIPPolicy(
 				deno.DisallowGlobalUnicast,
 				deno.DisallowInterfaceLocalMulticast,


### PR DESCRIPTION
This PR does the following things

1. Upgrade go to 1.23
2. Upgrade golangci-lint so that it is compatible with go 1.23
3. Setup flake.
4. Use `embed` to embed runtime files. (runner.ts)
5. Set up multi platform build