### PR TITLE
Update go to 1.25.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/deno/testdata/**/*.out
 pkg/deno/testdata/**/*.out
+deno.lock

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,27 +1,62 @@
+version: "2"
 linters:
-  disable:
-  - wrapcheck
-  - gofumpt
-  - revive
-  - tagalign
-  - depguard
-  - musttag
-  presets:
-  - bugs
-  - error
-  - format
-  - import
-  - metalinter
-  - performance
-  - sql
+  default: none
+  enable:
+  - gosec
+  - govet
+  - ineffassign
+  - misspell
+  - errcheck
   - unused
-linters-settings:
-  gci:
-    sections:
-    - standard
-    - default
-    - prefix(github.com/authgear/authgear-deno)
-    - dot
-  gocritic:
-    disabled-checks:
-    - sloppyLen
+  - gocognit
+  # Detect potential fat context in loops.
+  # https://github.com/Crocmagnon/fatcontext
+  - fatcontext
+  # I tried turning on contextcheck but it has many false positives.
+  #- contextcheck
+  # https://github.com/golangci/golangci-lint/pull/2438
+  # Disable linter that does not work with go1.18
+  #- staticcheck
+  #- gosimple
+  settings:
+    gosec:
+      excludes:
+      - G404 # G404: Use of weak random number generator (math/rand instead of crypto/rand)
+      # We use errcheck to check unhandled errors.
+      - G104 # G104: Errors unhandled
+      - G304 # G304: Potential file inclusion via variable
+      - G301 # G301: Expect directory permissions to be 0750 or less
+      - G302 # G302: Expect file permissions to be 0600 or less
+    govet:
+      # We want to enable all govet analyzers.
+      enable-all: true
+      disable:
+        # If fieldalignment is enabled, we have many errors because all of our structs are not sorted to minimize memory.
+        - fieldalignment
+        # We shadow variables in a lot of places. Enabling this will generate many errors.
+        - shadow
+    errcheck:
+      exclude-functions:
+      - fmt.Fprintf
+      - (io.ReadCloser).Close
+      - (io.Closer).Close
+      - (*os.File).Close
+      - (io/fs.File).Close
+      - os.Remove
+      - (*database/sql.Rows).Close
+      - os.Setenv
+  exclusions:
+    rules:
+    # Exclude errcheck and gosec in test files.
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gosec
+
+issues:
+  max-issues-per-linter: 0
+
+formatters:
+  settings:
+    gofmt:
+      simplify: false

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.25.4
+golang 1.25.6
 deno 1.41.3

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGE_TAG ?= quay.io/theauthgear/authgear-deno:$(GIT_HASH)
 
 .PHONY: vendor
 vendor:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.64.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.5.0
 	go mod download
 
 .PHONY: start

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/theauthgear/golang:1.23.6-noble AS stage1
+FROM quay.io/theauthgear/golang:1.25.6-noble AS stage1
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/authgear/authgear-deno
 
 // go1.21 supports toolchain
 // See https://go.dev/doc/toolchain
-go 1.23.6
+go 1.25.6
 
 require (
 	github.com/creack/pty v1.1.21

--- a/pkg/deno/checker.go
+++ b/pkg/deno/checker.go
@@ -43,7 +43,7 @@ func (c *Checker) CheckFile(ctx context.Context, opts CheckFileOptions) error {
 		return err
 	}
 
-	cmd := exec.CommandContext(
+	cmd := exec.CommandContext( // #nosec G204
 		ctx,
 		"deno",
 		"check",

--- a/pkg/ioutil/writer.go
+++ b/pkg/ioutil/writer.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-// LimitedWriter stops writting to the underlying W when
+// LimitedWriter stops writing to the underlying W when
 // N is non-positive.
 // Unlike [io.LimitedReader], it does not return error when the limit exceeds.
 type LimitedWriter[T io.Writer] struct {


### PR DESCRIPTION
ref DEV-3250

Tried to update deno to v2 as well, but seems tests hang and cannot be fixed easily. Created https://linear.app/authgear/issue/DEV-3389/update-deno-to-v2-in-authgear-deno